### PR TITLE
Add french localization

### DIFF
--- a/css/Follow.css
+++ b/css/Follow.css
@@ -18,7 +18,7 @@
 .feed-follow .text-follow, .feed-follow .text-following {
 	max-width: 0px; opacity: 0; overflow: hidden; display: inline-block; vertical-align: bottom; transition: all 0.3s; white-space: nowrap;
 }
-.feed-follow .text-follow { max-width: 120px; opacity: 1 }
+.feed-follow .text-follow { max-width: 170px; opacity: 1 }
 .feed-follow.following .text-following { max-width: 60px; opacity: 1; color: #7A26E2; }
 .feed-follow.following .text-follow { max-width: 0px; opacity: 0 }
 

--- a/css/all.css
+++ b/css/all.css
@@ -79,7 +79,7 @@ input.text:focus, textarea:focus { border-color: #5FC0EA; outline: none; backgro
 .feed-follow .text-follow, .feed-follow .text-following {
 	max-width: 0px; opacity: 0; overflow: hidden; display: inline-block; vertical-align: bottom; -webkit-transition: all 0.3s; -moz-transition: all 0.3s; -o-transition: all 0.3s; -ms-transition: all 0.3s; transition: all 0.3s ; white-space: nowrap;
 }
-.feed-follow .text-follow { max-width: 120px; opacity: 1 }
+.feed-follow .text-follow { max-width: 170px; opacity: 1 }
 .feed-follow.following .text-following { max-width: 60px; opacity: 1; color: #7A26E2; }
 .feed-follow.following .text-follow { max-width: 0px; opacity: 0 }
 

--- a/languages/fr.json
+++ b/languages/fr.json
@@ -1,0 +1,53 @@
+{
+    "Add new post": "Ajouter un article",
+    "Follow in Newsfeed": "Suivre dans le fil d'actualités",
+    "Username mentions": "Mentions",
+    "Posts": "Articles",
+    "0 Comments:": "0 Commentaire :",
+    "Comments": "Commentaires",
+    "Following": "Suivi",
+
+    "Like this post": "Aimer cet article",
+    "Latest comments:": "Derniers commentaires :",
+    "Reply": "Répondre",
+
+    "Bold": "Gras",
+    "Italic": "Italique",
+    "Strikethrough": "Strikethrough",
+    "Code": "Code",
+    "Link": "Lien",
+    "Type or paste link here": "Écrire ou copier le lien ici",
+
+    "**bold**": "**gras**",
+    "_italic_": "_italique_",
+    "strikethrough": "barré",
+    "- Lists": "- Listes",
+    "1. Numbered lists": "1. Listes numérotées",
+    "[Links](http://www.zeronet.io)": "[Liens](http://www.zeronet.io)",
+    "[References][1]<br>[1]: Can be used": "[Référence][1]<br>[1]: Peut être utilisé",
+    "&gt; Quotes": "&gt; Citations",
+    "--- Horizontal rule": "--- Barre horizontale",
+
+    "More comments": "Plus de commentaires...",
+    "Sign in as...": "Se connecter...",
+    "Submit comment": "Commenter",
+    "Please sign in": "Veuillez vous connecter",
+    "new comment": "Nouveau commentaire",
+    "used: ": "Utilisé : ",
+
+    " minutes ago": " minutes",
+    " hours ago": " heures",
+    " days ago": " jours",
+    "on ": "le ",
+    "Just now": "À l'instant",
+    "less than 1 min read": "moins d'une minute de lecture",
+    " min read": " minutes de lecture",
+
+    "Content changed": "Contenu modifié",
+    "Sign &amp; Publish new content": "Signer et publier le nouveau contenu",
+
+    " Editing: ": " Édition de : ",
+    "Save": "Enregistrer",
+    "Cancel": "Annuler",
+    "Delete ": "Supprimer "
+}


### PR DESCRIPTION
I added a french translation for the whole zite. I also translated things that are not currently translated into other languages, as the read time or the tips for writing markdown.
I also modified css to avoid having the translation for `Follow in Newsfeed` partially hidden.